### PR TITLE
Publish tweets only when there is new information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ auth.py
 covid-spain-twitter-machine.pem
 today_cases.jpg
 vaccines_today.jpg
+last_cases.txt

--- a/covid.py
+++ b/covid.py
@@ -1,83 +1,101 @@
 import logging
-import sys
 from datetime import date, datetime
+from time import sleep
 from get_data import get_vaccines, get_cases
 from tweet_image import generate_cases_image, generate_vaccine_image
 from send_tweet import send_tweet
-from prepare_data import dot_in_string, str_with_plus_symbol, read_yesterday_data, write_in_yesterday
+from prepare_data import dot_in_string, str_with_plus_symbol, read_yesterday_data, write_in_yesterday, \
+    read_from_last_cases, write_last_cases
 
 POBLACION_ESP = 47450795    # https://www.ine.es/jaxi/Tabla.htm?path=/t20/e245/p08/l0/&file=02003.px&L=0
+TWO_HOURS_IN_SECONDS = 60 * 60 * 2
+TEN_MINUTES_IN_SECONDS = 60 * 10
+
 
 logging.basicConfig(filename='covid.log', level=logging.DEBUG)
 
-# There is no new info posted on weekends so there is no need to create a tweet
-if datetime.today().weekday() in [5, 6]:
-    logging.debug("No info needs to be posted on weekends")
-    sys.exit()
 
-new_cases, new_deaths = get_cases()
-new_distributed, new_administered, new_completed = get_vaccines()
+while True:
+    # There is no new info posted on weekends so there is no need to create a tweet
+    if datetime.today().weekday() in [5, 6]:
+        logging.debug("No info needs to be posted on weekends, going to sleep for six hours")
+        sleep(TWO_HOURS_IN_SECONDS * 3)
 
-logging.debug("Cases and vaccines obtained")
+    new_distributed, new_administered, new_completed = get_vaccines()
+    new_cases, new_deaths = get_cases()
+    old_cases, old_deaths = read_from_last_cases()
 
-old_distributed, old_administered, old_completed = read_yesterday_data()
+    if old_cases == new_cases and old_deaths == new_deaths:
+        logging.debug("No new information was found, going to sleep for ten minutes")
+        sleep(TEN_MINUTES_IN_SECONDS)
+        continue
 
-write_in_yesterday(new_distributed, new_administered, new_completed)
+    write_last_cases(new_cases, new_deaths)
 
-logging.debug("Numbers for tomorrow statistics written in yesterday.txt")
+    logging.debug("Cases and vaccines obtained")
 
-diff_distributed = int(new_distributed.replace('.', '')) - old_distributed
-diff_administered = int(new_administered.replace('.', '')) - old_administered
-diff_completed = int(new_completed.replace('.', '')) - old_completed
+    old_distributed, old_administered, old_completed = read_yesterday_data()
 
-diff_distributed_str = dot_in_string(str_with_plus_symbol(diff_distributed))
-diff_administered_str = dot_in_string(str_with_plus_symbol(diff_administered))
-diff_completed_str = dot_in_string(str_with_plus_symbol(diff_completed))
+    write_in_yesterday(new_distributed, new_administered, new_completed)
 
-percentage_first = (((int(new_administered.replace('.', '')) - int(new_completed.replace('.', ''))) / POBLACION_ESP)
-                    * 100)
-percentage_completed = (int(new_completed.replace('.', '')) / POBLACION_ESP) * 100
+    logging.debug("Numbers for tomorrow statistics written in yesterday.txt")
 
-today = date.today()
-day = today.strftime("%d/%m/%Y")
+    diff_distributed = int(new_distributed.replace('.', '')) - old_distributed
+    diff_administered = int(new_administered.replace('.', '')) - old_administered
+    diff_completed = int(new_completed.replace('.', '')) - old_completed
 
-tweet_cases = ('Información COVID-19 ' + day + ' 🇪🇸\n\n' + '‣ Casos: ' + new_cases + '\n‣ Fallecimientos: ' + new_deaths
-               + '\n\n#COVID19España')
+    diff_distributed_str = dot_in_string(str_with_plus_symbol(diff_distributed))
+    diff_administered_str = dot_in_string(str_with_plus_symbol(diff_administered))
+    diff_completed_str = dot_in_string(str_with_plus_symbol(diff_completed))
 
-tweet_vaccines = ('Información vacunas ' + day + ' 🇪🇸\n\n' + '‣ Vacunas distribuidas: ' + new_distributed + ' (' +
-                  diff_distributed_str + ')' + '\n‣ Administradas: ' + new_administered + ' (' + diff_administered_str
-                  + ')' + '\n‣ Completas: ' + new_completed + ' (' + diff_completed_str + ')' + '\n\n' +
-                  'Población inmunizada: {:.2f}%\n\n#COVID19España'.format(percentage_completed))
+    percentage_first = (((int(new_administered.replace('.', '')) - int(new_completed.replace('.', ''))) / POBLACION_ESP)
+                        * 100)
+    percentage_completed = (int(new_completed.replace('.', '')) / POBLACION_ESP) * 100
 
-logging.debug("Starting to generate the cases image")
+    today = date.today()
+    day = today.strftime("%d/%m/%Y")
 
-try:
-    generate_cases_image(new_cases, new_deaths)
-except OSError:
-    logging.error("Couldn't generate the cases image")
-else:
-    logging.debug("Cases image ready")
+    tweet_cases = ('Información COVID-19 ' + day + ' 🇪🇸\n\n' + '‣ Casos: ' + new_cases + '\n‣ Fallecimientos: ' +
+                   new_deaths + '\n\n#COVID19España')
 
-logging.debug("Starting to generate the vaccines image")
+    tweet_vaccines = ('Información vacunas ' + day + ' 🇪🇸\n\n' + '‣ Vacunas distribuidas: ' + new_distributed + ' (' +
+                      diff_distributed_str + ')' + '\n‣ Administradas: ' + new_administered + ' (' +
+                      diff_administered_str + ')' + '\n‣ Completas: ' + new_completed + ' (' + diff_completed_str + ')'
+                      + '\n\n' + 'Población inmunizada: {:.2f}%\n\n#COVID19España'.format(percentage_completed))
 
-text_primera_dosis = dot_in_string(str((int(new_administered.replace('.', '')) -
-                                        int(new_completed.replace('.', ''))))) + ' ({:.2f}%)'.format(percentage_first)
-text_completa = new_completed + ' ({:.2f}%)'.format(percentage_completed)
+    logging.debug("Starting to generate the cases image")
 
-try:
-    generate_vaccine_image(percentage_first, text_primera_dosis, percentage_completed, text_completa, day)
-except OSError:
-    logging.error("Couldn't generate the vaccines image")
-else:
-    logging.debug("Vaccines image ready")
+    try:
+        generate_cases_image(new_cases, new_deaths)
+    except OSError:
+        logging.error("Couldn't generate the cases image")
+    else:
+        logging.debug("Cases image ready")
 
-logging.debug("Tweets ready to send")
+    logging.debug("Starting to generate the vaccines image")
 
-# print(tweet_cases)
-# print('\n')
-# print(tweet_vaccines)
+    text_primera_dosis = (dot_in_string(str((int(new_administered.replace('.', '')) -
+                                             int(new_completed.replace('.', ''))))) +
+                          ' ({:.2f}%)'.format(percentage_first))
+    text_completa = new_completed + ' ({:.2f}%)'.format(percentage_completed)
 
-logging.debug("Attempt to send the tweets")
+    try:
+        generate_vaccine_image(percentage_first, text_primera_dosis, percentage_completed, text_completa, day)
+    except OSError:
+        logging.error("Couldn't generate the vaccines image")
+    else:
+        logging.debug("Vaccines image ready")
 
-send_tweet(tweet_cases, 'today_cases.jpg')
-send_tweet(tweet_vaccines, 'vaccines_today.jpg')
+    logging.debug("Tweets ready to send")
+
+    # print(tweet_cases)
+    # print('\n')
+    # print(tweet_vaccines)
+
+    logging.debug("Attempt to send the tweets")
+
+    send_tweet(tweet_cases, 'today_cases.jpg')
+    send_tweet(tweet_vaccines, 'vaccines_today.jpg')
+
+    logging.debug("Going to sleep for two hours")
+    sleep(TWO_HOURS_IN_SECONDS)

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -46,11 +46,11 @@ def read_yesterday_data():
     Returns
     -------
     old_distributed : int
-        Number read from 'yesterday.txt' referring to distributed vaccines
+        Number read from 'yesterday.txt' referring to distributed vaccines.
     old_administered : int
-        Number read from 'yesterday.txt' referring to administered vaccines
+        Number read from 'yesterday.txt' referring to administered vaccines.
     old_completed : int
-        Number read from 'yesterday.txt' referring to completed vaccines
+        Number read from 'yesterday.txt' referring to completed vaccines.
     '''
     old_distributed = 0
     old_administered = 0
@@ -76,11 +76,11 @@ def write_in_yesterday(distributed, administered, complete):
     Parameters
     ----------
     distributed : str
-        Distributed vaccines to be written in 'yesterday.txt'
+        Distributed vaccines to be written in 'yesterday.txt'.
     administered : str
-        Administered vaccines to be written in 'yesterday.txt'
+        Administered vaccines to be written in 'yesterday.txt'.
     complete : str
-        Completed vaccines to be written in 'yesterday.txt'
+        Completed vaccines to be written in 'yesterday.txt'.
     '''
     try:
         with open('yesterday.txt', 'w') as f:
@@ -92,3 +92,47 @@ def write_in_yesterday(distributed, administered, complete):
             f.write('\n')
     except OSError:
         logging.error("Could not write data into 'yesterday.txt'")
+
+
+def read_from_last_cases():
+    '''
+    Get cases and deaths info from last day from file 'last_cases.txt'.
+
+    Returns
+    -------
+    last_cases : str
+        Number of COVID-19 cases in Spain the last day.
+    last_cases : str
+        Number of COVID-19 deaths in Spain the last day.
+    '''
+    try:
+        with open('last_cases.txt', 'r') as f:
+            lines = f.readlines()
+
+            last_cases = lines[0].strip().replace(',', '.')
+            last_deaths = lines[1].strip().replace(',', '.')
+
+            return last_cases, last_deaths
+    except OSError:
+        logging.error("Could not read data from 'last_cases.txt")
+
+
+def write_last_cases(new_cases, new_deaths):
+    '''
+    Write cases and deaths info from today in 'last_cases.txt'.
+
+    Parameters
+    -------
+    new_cases : str
+        Number of COVID-19 cases in Spain today.
+    new_deaths : str
+        Number of COVID-19 deaths in Spain today.
+    '''
+    try:
+        with open('last_cases.txt', 'w') as f:
+            f.write(new_cases)
+            f.write('\n')
+            f.write(new_deaths)
+            f.write('\n')
+    except OSError:
+        logging.error("Could not write data into 'last_cases.txt'")


### PR DESCRIPTION
With this pull request, there is no new for automating the script with `cron`. The script will check with the webpage the cases and deaths, if they are exactly the same ones from the previous day, nothing will be published and it will try again in 10 minutes. If there is new information, the data will be published and the script will go to sleep for 2 hours.

Closes #20.